### PR TITLE
Update indexing code

### DIFF
--- a/sts_params_internal.R
+++ b/sts_params_internal.R
@@ -5,6 +5,8 @@ PARQUET_BUCKET <- 'recover-processed-data'
 
 PARQUET_BUCKET_BASE_KEY <- 'main/parquet/'
 
+PARQUET_BUCKET_BASE_KEY_ARCHIVE <- 'main/archive/'
+
 PARQUET_FOLDER <- 'syn51406699'
 
 # Local location where parquet bucket files are synced to

--- a/sts_synindex_internal.R
+++ b/sts_synindex_internal.R
@@ -44,72 +44,72 @@ manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse ma
 system(manifest_cmd)
 
 
-# #### Index S3 Objects in Synapse ####
-# 
-# ## Get a list of all files to upload and their synapse locations(parentId) 
-# STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION <- stringr::str_length(AWS_PARQUET_DOWNLOAD_LOCATION)
-# 
-# ## All files present locally from manifest
-# synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>% 
-#   dplyr::filter(path != paste0(AWS_PARQUET_DOWNLOAD_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
-#   dplyr::rowwise() %>% 
-#   dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION+2)) %>% # location of file from home folder of S3 bucket
-#   dplyr::mutate(s3_file_key = paste0('main/parquet/', file_key)) %>% # the namespace for files in the S3 bucket is S3::bucket/main/
-#   dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>% 
-#   dplyr::ungroup()
-# 
-# ## All currently indexed files in Synapse
-# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-# 
-# ## find those files that are not in the fileview - files that need to be indexed
-# if (nrow(synapse_fileview)>0) {
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest %>% 
-#     dplyr::anti_join(
-#       synapse_fileview %>% 
-#         dplyr::select(parent = parentId,
-#                       s3_file_key = dataFileKey,
-#                       md5_hash = dataFileMD5Hex))
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest_to_upload %>% 
-#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
-#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-# } else {
-#   synapse_manifest_to_upload <- 
-#     synapse_manifest %>% 
-#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
-#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-# }
-# 
-# ## Index in Synapse
-# ## For each file index it in Synapse given a parent synapse folder
-# if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
-#   for(file_number in seq(nrow(synapse_manifest_to_upload))){
-#     
-#     # file and related synapse parent id 
-#     file_= synapse_manifest_to_upload$path[file_number]
-#     parent_id = synapse_manifest_to_upload$parent[file_number]
-#     s3_file_key = synapse_manifest_to_upload$s3_file_key[file_number]
-#     # this would be the location of the file in the S3 bucket, in the local it is at {AWS_PARQUET_DOWNLOAD_LOCATION}/
-#     
-#     absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
-#     
-#     temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
-#       bucket_name = PARQUET_BUCKET,
-#       s3_file_key = s3_file_key, #
-#       file_path = absolute_file_path,
-#       parent = parent_id
-#     )
-#     
-#     # synapse does not accept ':' (colon) in filenames, so replacing it with '_colon_'
-#     new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
-#     
-#     f <- File(dataFileHandleId=temp_syn_obj$id,
-#               parentId=parent_id,
-#               name = new_fileName) ## set the new file name
-#     
-#     f <- synStore(f)
-#     
-#   }
-# }
+#### Index S3 Objects in Synapse ####
+
+## Get a list of all files to upload and their synapse locations(parentId)
+STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION <- stringr::str_length(AWS_PARQUET_DOWNLOAD_LOCATION)
+
+## All files present locally from manifest
+synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>%
+  dplyr::filter(path != paste0(AWS_PARQUET_DOWNLOAD_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
+  dplyr::rowwise() %>%
+  dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION+2)) %>% # location of file from home folder of S3 bucket
+  dplyr::mutate(s3_file_key = paste0('main/parquet/', file_key)) %>% # the namespace for files in the S3 bucket is S3::bucket/main/
+  dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>%
+  dplyr::ungroup()
+
+## All currently indexed files in Synapse
+synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
+synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
+
+## find those files that are not in the fileview - files that need to be indexed
+if (nrow(synapse_fileview)>0) {
+  synapse_manifest_to_upload <-
+    synapse_manifest %>%
+    dplyr::anti_join(
+      synapse_fileview %>%
+        dplyr::select(parent = parentId,
+                      s3_file_key = dataFileKey,
+                      md5_hash = dataFileMD5Hex))
+  synapse_manifest_to_upload <-
+    synapse_manifest_to_upload %>%
+    mutate(file_key = gsub("cohort_", "cohort=", file_key),
+           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+} else {
+  synapse_manifest_to_upload <-
+    synapse_manifest %>%
+    mutate(file_key = gsub("cohort_", "cohort=", file_key),
+           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+}
+
+## Index in Synapse
+## For each file index it in Synapse given a parent synapse folder
+if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
+  for(file_number in seq(nrow(synapse_manifest_to_upload))){
+
+    # file and related synapse parent id
+    file_= synapse_manifest_to_upload$path[file_number]
+    parent_id = synapse_manifest_to_upload$parent[file_number]
+    s3_file_key = synapse_manifest_to_upload$s3_file_key[file_number]
+    # this would be the location of the file in the S3 bucket, in the local it is at {AWS_PARQUET_DOWNLOAD_LOCATION}/
+
+    absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
+
+    temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
+      bucket_name = PARQUET_BUCKET,
+      s3_file_key = s3_file_key, #
+      file_path = absolute_file_path,
+      parent = parent_id
+    )
+
+    # synapse does not accept ':' (colon) in filenames, so replacing it with '_colon_'
+    new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
+
+    f <- File(dataFileHandleId=temp_syn_obj$id,
+              parentId=parent_id,
+              name = new_fileName) ## set the new file name
+
+    f <- synStore(f)
+
+  }
+}

--- a/sts_synindex_internal.R
+++ b/sts_synindex_internal.R
@@ -1,5 +1,25 @@
 library(magrittr)
 
+# Functions ---------------------------------------------------------------
+
+#' Replace equal sign with underscore
+#'
+#' This function renames a directory path by replacing equal signs with underscores.
+#' If a replacement is performed, it logs the change.
+#'
+#' @param directory_path The path of the directory to rename.
+#'
+#' @examples
+#' replace_equal_with_underscore("path_with=equals")
+#' 
+replace_equal_with_underscore <- function(directory_path) {
+  new_directory_path <- gsub("=", "_", directory_path)
+  if (directory_path != new_directory_path) {
+    file.rename(directory_path, new_directory_path)
+    return(cat("Renamed:", directory_path, "to", new_directory_path, "\n"))
+  }
+}
+
 synapser::synLogin(authToken = Sys.getenv('SYNAPSE_AUTH_TOKEN'))
 source('~/recover-parquet-internal/sts_params_internal.R')
 
@@ -26,15 +46,6 @@ Sys.setenv('AWS_ACCESS_KEY_ID'=token$accessKeyId,
 unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
 sync_cmd <- glue::glue('aws s3 sync {base_s3_uri} {AWS_PARQUET_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
 system(sync_cmd)
-
-# Modify cohort identifier in dir name
-replace_equal_with_underscore <- function(directory_path) {
-  new_directory_path <- gsub("=", "_", directory_path)
-  if (directory_path != new_directory_path) {
-    file.rename(directory_path, new_directory_path)
-    return(cat("Renamed:", directory_path, "to", new_directory_path, "\n"))
-  }
-}
 
 junk <- invisible(lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION), replace_equal_with_underscore))
 

--- a/sts_synindex_internal.R
+++ b/sts_synindex_internal.R
@@ -31,6 +31,17 @@ unlink(AWS_PARQUET_DOWNLOAD_LOCATION, recursive = T, force = T)
 sync_cmd <- glue::glue('aws s3 sync {base_s3_uri} {AWS_PARQUET_DOWNLOAD_LOCATION} --exclude "*owner.txt*" --exclude "*archive*"')
 system(sync_cmd)
 
+
+# Upload parquet datasets directory tree to Synapse ------------------------
+
+existing_dirs <- synGetChildren(PARQUET_FOLDER) %>% as.list()
+
+if(length(existing_dirs)>0) {
+  for (i in seq_along(existing_dirs)) {
+    synDelete(existing_dirs[[i]]$id)
+  }
+}
+
 # Modify cohort identifier in dir name
 replace_equal_with_underscore <- function(directory_path) {
   new_directory_path <- gsub("=", "_", directory_path)
@@ -42,84 +53,78 @@ replace_equal_with_underscore <- function(directory_path) {
 
 invisible(lapply(list.dirs(AWS_PARQUET_DOWNLOAD_LOCATION), replace_equal_with_underscore))
 
-#### Index S3 Objects in Synapse ####
-existing_dirs <- synGetChildren(PARQUET_FOLDER) %>% as.list()
-
-if(length(existing_dirs)>0) {
-  for (i in seq_along(existing_dirs)) {
-    synDelete(existing_dirs[[i]]$id)
-  }
-}
-
 # Generate manifest of existing files
 SYNAPSE_AUTH_TOKEN <- Sys.getenv('SYNAPSE_AUTH_TOKEN')
 manifest_cmd <- glue::glue('SYNAPSE_AUTH_TOKEN="{SYNAPSE_AUTH_TOKEN}" synapse manifest --parent-id {SYNAPSE_PARENT_ID} --manifest ./current_manifest.tsv {AWS_PARQUET_DOWNLOAD_LOCATION}')
 system(manifest_cmd)
 
-## Get a list of all files to upload and their synapse locations(parentId) 
-STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION <- stringr::str_length(AWS_PARQUET_DOWNLOAD_LOCATION)
 
-## All files present locally from manifest
-synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>% 
-  dplyr::filter(path != paste0(AWS_PARQUET_DOWNLOAD_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
-  dplyr::rowwise() %>% 
-  dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION+2)) %>% # location of file from home folder of S3 bucket
-  dplyr::mutate(s3_file_key = paste0('main/parquet/', file_key)) %>% # the namespace for files in the S3 bucket is S3::bucket/main/
-  dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>% 
-  dplyr::ungroup()
-
-## All currently indexed files in Synapse
-synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
-
-## find those files that are not in the fileview - files that need to be indexed
-if (nrow(synapse_fileview)>0) {
-  synapse_manifest_to_upload <- 
-    synapse_manifest %>% 
-    dplyr::anti_join(
-      synapse_fileview %>% 
-        dplyr::select(parent = parentId,
-                      s3_file_key = dataFileKey,
-                      md5_hash = dataFileMD5Hex))
-  synapse_manifest_to_upload <- 
-    synapse_manifest_to_upload %>% 
-    mutate(file_key = gsub("cohort_", "cohort=", file_key),
-           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-} else {
-  synapse_manifest_to_upload <- 
-    synapse_manifest %>% 
-    mutate(file_key = gsub("cohort_", "cohort=", file_key),
-           s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
-}
-
-## Index in Synapse
-## For each file index it in Synapse given a parent synapse folder
-if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
-  for(file_number in seq(nrow(synapse_manifest_to_upload))){
-    
-    # file and related synapse parent id 
-    file_= synapse_manifest_to_upload$path[file_number]
-    parent_id = synapse_manifest_to_upload$parent[file_number]
-    s3_file_key = synapse_manifest_to_upload$s3_file_key[file_number]
-    # this would be the location of the file in the S3 bucket, in the local it is at {AWS_PARQUET_DOWNLOAD_LOCATION}/
-    
-    absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
-    
-    temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
-      bucket_name = PARQUET_BUCKET,
-      s3_file_key = s3_file_key, #
-      file_path = absolute_file_path,
-      parent = parent_id
-    )
-    
-    # synapse does not accept ':' (colon) in filenames, so replacing it with '_colon_'
-    new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
-    
-    f <- File(dataFileHandleId=temp_syn_obj$id,
-              parentId=parent_id,
-              name = new_fileName) ## set the new file name
-    
-    f <- synStore(f)
-    
-  }
-}
+# #### Index S3 Objects in Synapse ####
+# 
+# ## Get a list of all files to upload and their synapse locations(parentId) 
+# STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION <- stringr::str_length(AWS_PARQUET_DOWNLOAD_LOCATION)
+# 
+# ## All files present locally from manifest
+# synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFactors = F) %>% 
+#   dplyr::filter(path != paste0(AWS_PARQUET_DOWNLOAD_LOCATION,'/owner.txt')) %>%  # need not create a dataFileHandleId for owner.txt
+#   dplyr::rowwise() %>% 
+#   dplyr::mutate(file_key = stringr::str_sub(string = path, start = STR_LEN_AWS_PARQUET_DOWNLOAD_LOCATION+2)) %>% # location of file from home folder of S3 bucket
+#   dplyr::mutate(s3_file_key = paste0('main/parquet/', file_key)) %>% # the namespace for files in the S3 bucket is S3::bucket/main/
+#   dplyr::mutate(md5_hash = as.character(tools::md5sum(path))) %>% 
+#   dplyr::ungroup()
+# 
+# ## All currently indexed files in Synapse
+# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
+# synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
+# 
+# ## find those files that are not in the fileview - files that need to be indexed
+# if (nrow(synapse_fileview)>0) {
+#   synapse_manifest_to_upload <- 
+#     synapse_manifest %>% 
+#     dplyr::anti_join(
+#       synapse_fileview %>% 
+#         dplyr::select(parent = parentId,
+#                       s3_file_key = dataFileKey,
+#                       md5_hash = dataFileMD5Hex))
+#   synapse_manifest_to_upload <- 
+#     synapse_manifest_to_upload %>% 
+#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
+#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+# } else {
+#   synapse_manifest_to_upload <- 
+#     synapse_manifest %>% 
+#     mutate(file_key = gsub("cohort_", "cohort=", file_key),
+#            s3_file_key = gsub("cohort_", "cohort=", s3_file_key))
+# }
+# 
+# ## Index in Synapse
+# ## For each file index it in Synapse given a parent synapse folder
+# if(nrow(synapse_manifest_to_upload) > 0){ # there are some files to upload
+#   for(file_number in seq(nrow(synapse_manifest_to_upload))){
+#     
+#     # file and related synapse parent id 
+#     file_= synapse_manifest_to_upload$path[file_number]
+#     parent_id = synapse_manifest_to_upload$parent[file_number]
+#     s3_file_key = synapse_manifest_to_upload$s3_file_key[file_number]
+#     # this would be the location of the file in the S3 bucket, in the local it is at {AWS_PARQUET_DOWNLOAD_LOCATION}/
+#     
+#     absolute_file_path <- tools::file_path_as_absolute(file_) # local absolute path
+#     
+#     temp_syn_obj <- synapser::synCreateExternalS3FileHandle(
+#       bucket_name = PARQUET_BUCKET,
+#       s3_file_key = s3_file_key, #
+#       file_path = absolute_file_path,
+#       parent = parent_id
+#     )
+#     
+#     # synapse does not accept ':' (colon) in filenames, so replacing it with '_colon_'
+#     new_fileName <- stringr::str_replace_all(temp_syn_obj$fileName, ':', '_colon_')
+#     
+#     f <- File(dataFileHandleId=temp_syn_obj$id,
+#               parentId=parent_id,
+#               name = new_fileName) ## set the new file name
+#     
+#     f <- synStore(f)
+#     
+#   }
+# }

--- a/sts_synindex_internal.R
+++ b/sts_synindex_internal.R
@@ -70,6 +70,7 @@ synapse_manifest <- read.csv('./current_manifest.tsv', sep = '\t', stringsAsFact
 
 ## All currently indexed files in Synapse
 synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
+synapse_fileview <- synapser::synTableQuery(paste0('SELECT * FROM ', SYNAPSE_FILEVIEW_ID))$filepath %>% read.csv()
 
 ## find those files that are not in the fileview - files that need to be indexed
 if (nrow(synapse_fileview)>0) {


### PR DESCRIPTION
## Major Changes

1. Update indexing code to mirror up-to-date indexing code in recover-parquet-external pipeline
2. Do not delete existing directory structure in Parquet Internal Synapse folder since manifest command will update directory structure on each run

## Minor Changes

1. Create section at top of script for helper functions
3. Update params file with new parameters
4. Update section naming and comments
5. Remove unused library imports